### PR TITLE
Add support for stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT"
 default = ["std"]
 std = ["heap"]
 heap = []
+nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,10 +145,9 @@
 //! assert!(s.resize::<S16>().is_ok());
 //! ```
 
-#![feature(unsize)]
-#![feature(coerce_unsized)]
-#![feature(box_syntax)]
-#![feature(used)]
+#![cfg_attr(feature="std", feature(unsize))]
+#![cfg_attr(feature="std", feature(coerce_unsized))]
+#![cfg_attr(feature="std", feature(box_syntax))]
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="heap", not(feature="std")), feature(alloc))]

--- a/src/space.rs
+++ b/src/space.rs
@@ -18,36 +18,30 @@
 
 /// Represent as 2 * usize space
 pub struct S2 {
-    #[used]
-    inner: [usize; 2],
+    _inner: [usize; 2],
 }
 
 /// Represent as 4 * usize space
 pub struct S4 {
-    #[used]
-    inner: [usize; 4],
+    _inner: [usize; 4],
 }
 
 /// Represent as 8 * usize space
 pub struct S8 {
-    #[used]
-    inner: [usize; 8],
+    _inner: [usize; 8],
 }
 
 /// Represent as 16 * usize space
 pub struct S16 {
-    #[used]
-    inner: [usize; 16],
+    _inner: [usize; 16],
 }
 
 /// Represent as 32 * usize space
 pub struct S32 {
-    #[used]
-    inner: [usize; 32],
+    _inner: [usize; 32],
 }
 
 /// Represent as 64 * usize space
 pub struct S64 {
-    #[used]
-    inner: [usize; 64],
+    _inner: [usize; 64],
 }

--- a/tests/smallbox.rs
+++ b/tests/smallbox.rs
@@ -6,18 +6,35 @@ use smallbox::SmallBox;
 
 #[test]
 fn basic() {
-    let small_stack = SmallBox::<PartialEq<u32>>::new(4321u32);
+    let small_stack = SmallBox::<u32>::new(4321u32);
     assert!(*small_stack == 4321);
     match small_stack {
         SmallBox::Stack(_) => (),
         _ => unreachable!(),
     }
 
-    let small_heap = SmallBox::<[usize]>::new([5; 1000]);
+    let small_heap = SmallBox::<[usize; 1000]>::new([5; 1000]);
     assert!(small_heap.iter().eq([5; 1000].iter()));
     match small_heap {
         SmallBox::Box(_) => (),
         _ => unreachable!(),
+    }
+
+    #[cfg(feature = "nightly")]
+    {
+        let small_stack = SmallBox::<PartialEq<u32>>::new(4321u32);
+        assert!(*small_stack == 4321);
+        match small_stack {
+            SmallBox::Stack(_) => (),
+            _ => unreachable!(),
+        }
+
+        let small_heap = SmallBox::<[usize]>::new([5; 1000]);
+        assert!(small_heap.iter().eq([5; 1000].iter()));
+        match small_heap {
+            SmallBox::Box(_) => (),
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/tests/stackbox.rs
+++ b/tests/stackbox.rs
@@ -4,6 +4,10 @@ use smallbox::StackBox;
 
 #[test]
 fn basic() {
+    let stack = StackBox::<u32>::new(1234u32).unwrap();
+    assert!(*stack == 1234);
+
+    #[cfg(feature = "nightly")]
     let stack = StackBox::<PartialEq<u32>>::new(1234u32).unwrap();
     assert!(*stack == 1234);
 }


### PR DESCRIPTION
A new flag `nightly` is added that enables nightly features (the most important ones being `CoerceUnsized` and `Unsize`). Otherwise, stable Rust is supported but `SmallBox` can be used with sized types only.

This PR is still a work in progress. More tests need to be ported and the documentation needs to be updated. I'm submitting the PR early to check whether this is a direction we'd like to take at all.

To provide some context, I need `SmallBox` in https://github.com/crossbeam-rs/crossbeam-channel/pull/86