### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ catagory = "data-structures"
 readme = "README.md"
 keywords = ["box", "alloc", "dst", "stack", "no_std"]
 license = "MIT"
+edition = "2018"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,4 +157,4 @@ extern crate core as std;
 mod smallbox;
 pub mod space;
 
-pub use smallbox::SmallBox;
+pub use crate::smallbox::SmallBox;

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -443,7 +443,7 @@ unsafe impl<T: ?Sized + Sync, Space> Sync for SmallBox<T, Space> {}
 #[cfg(test)]
 mod tests {
     use super::SmallBox;
-    use space::*;
+    use crate::space::*;
     use std::any::Any;
 
     #[test]


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'