### PR TITLE
Fix miri issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --features nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["data-structures"]
 readme = "README.md"
 keywords = ["box", "alloc", "dst", "stack", "no_std"]
 license = "MIT"
+rust-version = "1.56"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ edition = "2021"
 default = ["std"]
 std = []
 coerce = []
+nightly = ["coerce"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,11 @@
 //!   - Require nightly rust
 //!   - Allow automatic coersion from sized `SmallBox` to unsized `SmallBox`.
 //!
+//! - `nightly`
+//!   - Optional
+//!   - Enables `coerce`
+//!   - Requires nightly rust
+//!   - Uses strict provenance operations to be compatible with `miri`
 //!
 //! # Unsized Type
 //!
@@ -149,7 +154,7 @@
 //! Please note that the space alignment is also important. If the alignment
 //! of the space is smaller than the alignment of the value, the value
 //! will be stored in the heap.
-#![feature(strict_provenance, set_ptr_value)]
+#![cfg_attr(feature = "nightly", feature(strict_provenance, set_ptr_value))]
 #![cfg_attr(feature = "coerce", feature(unsize, coerce_unsized))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(clippy::as_conversions)]
@@ -158,5 +163,6 @@ extern crate alloc;
 
 mod smallbox;
 pub mod space;
+mod sptr;
 
 pub use crate::smallbox::SmallBox;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,10 @@
 //! Please note that the space alignment is also important. If the alignment
 //! of the space is smaller than the alignment of the value, the value
 //! will be stored in the heap.
-
+#![feature(strict_provenance, set_ptr_value)]
 #![cfg_attr(feature = "coerce", feature(unsize, coerce_unsized))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(clippy::as_conversions)]
 
 extern crate alloc;
 

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -132,7 +132,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
             }
         } else {
             let val: &T = &this;
-            unsafe { SmallBox::<T, ToSpace>::new_copy(val, ptr::from_ref(val)) }
+            unsafe { SmallBox::<T, ToSpace>::new_copy(val, sptr::from_ref(val)) }
         }
     }
 
@@ -178,7 +178,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         // `self.ptr` always holds the metadata, even if stack allocated
         let ptr = sptr::with_metadata_of_mut(ptr_this, metadata_ptr);
 
-        ptr::copy_nonoverlapping(ptr::from_ref(val).cast(), val_dst, size);
+        ptr::copy_nonoverlapping(sptr::from_ref(val).cast(), val_dst, size);
 
         SmallBox {
             space,

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -55,7 +55,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized, Space> CoerceUnsized<SmallBox<U, Space>>
 macro_rules! smallbox {
     ( $e: expr ) => {{
         let val = $e;
-        let ptr = &val as *const _;
+        let ptr = ::core::ptr::addr_of!(val);
         #[allow(unsafe_code)]
         unsafe {
             $crate::SmallBox::new_unchecked(val, ptr)
@@ -66,7 +66,7 @@ macro_rules! smallbox {
 /// An optimized box that store value on stack or on heap depending on its size
 pub struct SmallBox<T: ?Sized, Space> {
     space: MaybeUninit<Space>,
-    ptr: *const T,
+    ptr: *mut T,
     _phantom: PhantomData<T>,
 }
 
@@ -130,7 +130,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
             }
         } else {
             let val: &T = &this;
-            unsafe { SmallBox::<T, ToSpace>::new_copy(val, val as *const T) }
+            unsafe { SmallBox::<T, ToSpace>::new_copy(val, ptr::from_ref(val)) }
         }
     }
 
@@ -153,15 +153,15 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         !self.ptr.is_null()
     }
 
-    unsafe fn new_copy<U>(val: &U, ptr: *const T) -> SmallBox<T, Space>
+    unsafe fn new_copy<U>(val: &U, metadata_ptr: *const T) -> SmallBox<T, Space>
     where U: ?Sized {
         let size = mem::size_of_val::<U>(val);
         let align = mem::align_of_val::<U>(val);
 
         let mut space = MaybeUninit::<Space>::uninit();
 
-        let (ptr_addr, ptr_copy): (*const u8, *mut u8) = if size == 0 {
-            (ptr::null(), align as *mut u8)
+        let (ptr_this, val_dst): (*mut u8, *mut u8) = if size == 0 {
+            (ptr::null_mut(), ptr::without_provenance_mut(align))
         } else if size > mem::size_of::<Space>() || align > mem::align_of::<Space>() {
             // Heap
             let layout = Layout::for_value::<U>(val);
@@ -170,15 +170,13 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
             (heap_ptr, heap_ptr)
         } else {
             // Stack
-            (ptr::null(), space.as_mut_ptr() as *mut u8)
+            (ptr::null_mut(), space.as_mut_ptr().cast())
         };
 
-        // Overwrite the pointer but retain any extra data inside the fat pointer.
-        let mut ptr = ptr;
-        let ptr_ptr = &mut ptr as *mut _ as *mut usize;
-        ptr_ptr.write(ptr_addr as usize);
+        // `self.ptr` always holds the metadata, even if stack allocated
+        let ptr = ptr_this.with_metadata_of(metadata_ptr);
 
-        ptr::copy_nonoverlapping(val as *const _ as *const u8, ptr_copy, size);
+        ptr::copy_nonoverlapping(ptr::from_ref(val).cast(), val_dst, size);
 
         SmallBox {
             space,
@@ -192,14 +190,14 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         let mut space = MaybeUninit::<Space>::uninit();
 
         if !self.is_heap() {
-            ptr::copy_nonoverlapping(
-                self.space.as_ptr() as *const u8,
-                space.as_mut_ptr() as *mut u8,
+            ptr::copy_nonoverlapping::<u8>(
+                self.space.as_ptr().cast(),
+                space.as_mut_ptr().cast(),
                 size,
             );
         };
 
-        let ptr = self.ptr as *const U;
+        let ptr = self.ptr.cast();
 
         mem::forget(self);
 
@@ -212,28 +210,20 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
 
     #[inline]
     unsafe fn as_ptr(&self) -> *const T {
-        let mut ptr = self.ptr;
-
-        if !self.is_heap() {
-            // Overwrite the pointer but retain any extra data inside the fat pointer.
-            let ptr_ptr = &mut ptr as *mut _ as *mut usize;
-            ptr_ptr.write(self.space.as_ptr() as *const () as usize);
+        if self.is_heap() {
+            self.ptr
+        } else {
+            self.space.as_ptr().with_metadata_of(self.ptr)
         }
-
-        ptr
     }
 
     #[inline]
     unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        let mut ptr = self.ptr;
-
-        if !self.is_heap() {
-            // Overwrite the pointer but retain any extra data inside the fat pointer.
-            let ptr_ptr = &mut ptr as *mut _ as *mut usize;
-            ptr_ptr.write(self.space.as_mut_ptr() as *mut () as usize);
+        if self.is_heap() {
+            self.ptr
+        } else {
+            self.space.as_mut_ptr().with_metadata_of(self.ptr)
         }
-
-        ptr as *mut _
     }
 
     /// Consumes the SmallBox and returns ownership of the boxed value
@@ -261,7 +251,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         if this.is_heap() {
             let layout = Layout::new::<T>();
             unsafe {
-                alloc::dealloc(this.ptr as *mut u8, layout);
+                alloc::dealloc(this.ptr.cast(), layout);
             }
         }
 
@@ -365,7 +355,7 @@ impl<T: ?Sized, Space> ops::Drop for SmallBox<T, Space> {
             let layout = Layout::for_value::<T>(&*self);
             ptr::drop_in_place::<T>(&mut **self);
             if self.is_heap() {
-                alloc::dealloc(self.ptr as *mut u8, layout);
+                alloc::dealloc(self.ptr.cast(), layout);
             }
         }
     }
@@ -445,6 +435,7 @@ unsafe impl<T: ?Sized + Sync, Space> Sync for SmallBox<T, Space> {}
 #[cfg(test)]
 mod tests {
     use core::any::Any;
+    use core::ptr::addr_of;
 
     use ::alloc::boxed::Box;
     use ::alloc::vec;
@@ -464,7 +455,7 @@ mod tests {
     #[test]
     fn test_new_unchecked() {
         let val = [0usize, 1];
-        let ptr = &val as *const _;
+        let ptr = addr_of!(val);
 
         unsafe {
             let stacked: SmallBox<[usize], S2> = SmallBox::new_unchecked(val, ptr);
@@ -473,7 +464,7 @@ mod tests {
         }
 
         let val = [0usize, 1, 2];
-        let ptr = &val as *const _;
+        let ptr = addr_of!(val);
 
         unsafe {
             let heaped: SmallBox<dyn Any, S2> = SmallBox::new_unchecked(val, ptr);

--- a/src/sptr.rs
+++ b/src/sptr.rs
@@ -1,0 +1,34 @@
+#[cfg(feature = "nightly")]
+mod implementation {
+    pub use core::ptr::without_provenance_mut;
+
+    pub fn with_metadata_of<T: ?Sized, U: ?Sized>(ptr: *const T, meta: *const U) -> *const U {
+        ptr.with_metadata_of(meta)
+    }
+
+    pub fn with_metadata_of_mut<T: ?Sized, U: ?Sized>(ptr: *mut T, meta: *const U) -> *mut U {
+        ptr.with_metadata_of(meta)
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+#[allow(clippy::as_conversions)]
+mod implementation {
+    use core::ptr::addr_of_mut;
+
+    pub fn without_provenance_mut<T>(addr: usize) -> *mut T {
+        addr as _
+    }
+
+    pub fn with_metadata_of<T: ?Sized, U: ?Sized>(ptr: *const T, meta: *const U) -> *const U {
+        with_metadata_of_mut(ptr.cast_mut(), meta)
+    }
+
+    pub fn with_metadata_of_mut<T: ?Sized, U: ?Sized>(ptr: *mut T, mut meta: *const U) -> *mut U {
+        let meta_ptr = addr_of_mut!(meta).cast::<usize>();
+        unsafe { meta_ptr.write(ptr.cast::<u8>() as usize) }
+        meta.cast_mut()
+    }
+}
+
+pub use implementation::*;

--- a/src/sptr.rs
+++ b/src/sptr.rs
@@ -16,19 +16,27 @@ mod implementation {
 mod implementation {
     use core::ptr::addr_of_mut;
 
+    fn cast_to_mut<T: ?Sized>(ptr: *const T) -> *mut T {
+        ptr as _
+    }
+
     pub fn without_provenance_mut<T>(addr: usize) -> *mut T {
         addr as _
     }
 
     pub fn with_metadata_of<T: ?Sized, U: ?Sized>(ptr: *const T, meta: *const U) -> *const U {
-        with_metadata_of_mut(ptr.cast_mut(), meta)
+        with_metadata_of_mut(cast_to_mut(ptr), meta)
     }
 
     pub fn with_metadata_of_mut<T: ?Sized, U: ?Sized>(ptr: *mut T, mut meta: *const U) -> *mut U {
         let meta_ptr = addr_of_mut!(meta).cast::<usize>();
         unsafe { meta_ptr.write(ptr.cast::<u8>() as usize) }
-        meta.cast_mut()
+        cast_to_mut(meta)
     }
+}
+
+pub fn from_ref<T: ?Sized>(val: &T) -> *const T {
+    val
 }
 
 pub use implementation::*;


### PR DESCRIPTION
This uses the proper strict provenance APIs, when a new `nightly` feature is enabled, in order to fix the miri test. This also just cleans up the jank being done to emulate `with_metadata_of`.