### PR TITLE
Fix strict provenance polyfills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,6 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test --features nightly
+        run: |
+          cargo miri test
+          cargo miri test --features nightly

--- a/src/sptr.rs
+++ b/src/sptr.rs
@@ -21,7 +21,7 @@ mod implementation {
     }
 
     pub fn without_provenance_mut<T>(addr: usize) -> *mut T {
-        addr as _
+        unsafe { core::mem::transmute(addr) }
     }
 
     pub fn with_metadata_of<T: ?Sized, U: ?Sized>(ptr: *const T, meta: *const U) -> *const U {
@@ -29,8 +29,8 @@ mod implementation {
     }
 
     pub fn with_metadata_of_mut<T: ?Sized, U: ?Sized>(ptr: *mut T, mut meta: *const U) -> *mut U {
-        let meta_ptr = addr_of_mut!(meta).cast::<usize>();
-        unsafe { meta_ptr.write(ptr.cast::<u8>() as usize) }
+        let meta_ptr = addr_of_mut!(meta).cast::<*mut u8>();
+        unsafe { meta_ptr.write(ptr.cast::<u8>()) }
         cast_to_mut(meta)
     }
 }


### PR DESCRIPTION
`without_provenance_mut` is more correctly implemented as a transmute: https://github.com/rust-lang/rust/blob/9ff5fc4ffbbe1e911527aa054e789b05ae55ffcc/library/core/src/ptr/mod.rs#L700

This `with_metadata_of_mut` polyfill scrubs provenance from the pointer it is trying to update, because it internally does a transmute to `usize` via pointer casts.

Together these changes make the crate pass Miri, no warnings even, with default features!