### PR TITLE
Fix `Any` usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ use std::any::Any;
 use smallbox::SmallBox;
 use smallbox::space::S2;
 
-let num: SmallBox<Any, S2> = smallbox!(1234u32);
+let num: SmallBox<dyn Any, S2> = smallbox!(1234u32);
 
 if let Some(num) = num.downcast_ref::<u32>() {
     assert_eq!(*num, 1234);


### PR DESCRIPTION
As is, gives a compiler error: `expected a type, found a trait`