### PR TITLE
fix: UB with overaligned ZSTs

### DIFF
--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -410,7 +410,7 @@ impl<T: ?Sized, Space> ops::Drop for SmallBox<T, Space> {
                 .unwrap_or_else(|_| unreachable_unchecked());
 
             ptr::drop_in_place::<T>(&mut **self);
-            if self.is_heap() && mem::size_of_val::<T>(&*self) != 0 {
+            if self.is_heap() && layout.size()!= 0 {
                 alloc::dealloc(self.ptr.as_ptr() as *mut u8, layout);
             }
         }


### PR DESCRIPTION
Fixes #46

When the inner type is zero sized, `ptr` inside `SmallBox` is now a dangling -- but well-aligned -- pointer. This allows safely turning it into a reference to any ZST with any alignment.

As a side effect, `SmallBox::is_heap` now returns true for ZSTs. If that's undesirable, it can be easily fixed