### PR TITLE
Ensure from_box works if boxed.addr() == 1

### DIFF
--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -328,14 +328,30 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
     /// assert_eq!(*small_box, [1, 2, 3, 4]);
     /// ```
     pub fn from_box(boxed: ::alloc::boxed::Box<T>) -> Self {
-        unsafe {
-            let ptr = NonNull::new_unchecked(Box::into_raw(boxed));
-            let space = MaybeUninit::<UnsafeCell<Space>>::uninit();
-            SmallBox {
-                space,
-                ptr,
-                _phantom: PhantomData,
+        if !ptr::addr_eq(&*boxed, INLINE_SENTINEL) {
+            // Normally, just reuse allocation from box
+            unsafe {
+                // Safety: Box contains a non-null pointer
+                let ptr = NonNull::new_unchecked(Box::into_raw(boxed));
+                let space = MaybeUninit::<UnsafeCell<Space>>::uninit();
+
+                // Safety: ptr points to a valid allocation which doesn't start at 0 or 1
+                SmallBox {
+                    space,
+                    ptr,
+                    _phantom: PhantomData,
+                }
             }
+        } else {
+            // If box allocation somehow ended up starting at 1, reallocate instead
+
+            // Make sure to deallocate box when done, but don't call drop of T
+            let non_drop = Box::into_raw(boxed) as *mut ManuallyDrop<T>;
+            // Safety: ManuallyDrop<T> has same layout as T, and non_drop came from a box of T.
+            let boxed = unsafe { Box::from_raw(non_drop) };
+
+            // Safety: metadata is valid for value, and T isn't dropped from box after copy
+            unsafe { SmallBox::new_copy(&**boxed, &**boxed) }
         }
     }
 


### PR DESCRIPTION
SmallBox::from_box will reuse the allocation from its argument as ptr in smallbox. However, said allocation might have an address of 1, which is the INLINE_SENTINAL value.

This would cause the resulting smallbox to read from its uninitialized inline storage space when de-referenced.

Note that this problem likely cannot be triggered on a desktop OS since the first page is typically set up to segfault when read. Thus if the type is not a ZST, then the allocator won't have given out a pointer in the first page, and if the type is a ZST, then reading from the uninitialized storage space is perfectly fine behavior.

However, bare metal programs could conceivably run into this problem, so this commit causes from_box to copy from boxed into a newly created smallbox if boxed.addr() == INLINE_SENTINEL.