### PR TITLE
Revert nonnull optimizations and remove as casts

### DIFF
--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -780,7 +780,7 @@ mod tests {
 
         let zst: SmallBox<OveralignedZst, S1> = smallbox!(OveralignedZst);
         #[allow(clippy::as_conversions)]
-        let zst_addr = addr_of!(*zst).addr();
+        let zst_addr = addr_of!(*zst) as usize;
         assert_eq!(*zst, OveralignedZst);
         assert_eq!(zst_addr % 512, 0);
     }
@@ -797,7 +797,7 @@ mod tests {
 
         let zst: SmallBox<dyn Foo, S1> = smallbox!(OveralignedZst);
         #[allow(clippy::as_conversions)]
-        let zst_addr = addr_of!(*zst).addr();
+        let zst_addr = addr_of!(*zst) as *const u8 as usize;
         assert_eq!(zst_addr % 512, 0);
     }
 

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -135,7 +135,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         let this = ManuallyDrop::new(self);
 
         if this.is_heap() {
-            // don't change anything if data is already on heap
+            // Do not change anything if data is already on heap.
             let space = MaybeUninit::<UnsafeCell<ToSpace>>::uninit();
             SmallBox {
                 space,
@@ -169,8 +169,8 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
 
     unsafe fn new_copy<U>(val: &U, metadata_ptr: *const T) -> SmallBox<T, Space>
     where U: ?Sized {
-        let size = mem::size_of_val(val);
-        let align = mem::align_of_val(val);
+        let layout = Layout::for_value(val);
+        let space_layout = Layout::new::<Space>();
 
         let mut space = MaybeUninit::<UnsafeCell<Space>>::uninit();
 
@@ -195,23 +195,11 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
 
                 (heap_ptr, heap_ptr)
             };
-            // Heap
-            let layout = Layout::for_value::<U>(val);
-            let heap_ptr = alloc::alloc(layout);
-
-            if heap_ptr.is_null() {
-                handle_alloc_error(layout)
-            }
-
-            (heap_ptr, heap_ptr)
-        } else {
-            (ptr::null_mut(), space.as_mut_ptr().cast())
-        };
 
         // `self.ptr` always holds the metadata, even if stack allocated.
         let ptr = sptr::with_metadata_of_mut(ptr_this, metadata_ptr);
 
-        ptr::copy_nonoverlapping(sptr::from_ref(val).cast(), val_dst, size);
+        ptr::copy_nonoverlapping(sptr::from_ref(val).cast(), val_dst, layout.size());
 
         SmallBox {
             space,
@@ -293,7 +281,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         ret_val
     }
 
-    /// Creates a [`SmallBox`] from a standard [`Box`].
+    /// Creates a [`SmallBox`] from a [`Box`].
     ///
     /// The data will always be stored on the heap since it's already allocated there.
     /// This method transfers ownership from the [`Box`] to the [`SmallBox`] without copying
@@ -324,7 +312,7 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
         }
     }
 
-    /// Converts a [`SmallBox`] into a standard [`Box`].
+    /// Converts a [`SmallBox`] into a [`Box`].
     ///
     /// If the data is stored on the stack, it will be moved to the heap.
     /// If the data is already on the heap, ownership is transferred without

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -5,7 +5,6 @@ use core::fmt;
 use core::future::Future;
 use core::hash::Hash;
 use core::hash::{self};
-use core::hint::unreachable_unchecked;
 use core::marker::PhantomData;
 #[cfg(feature = "coerce")]
 use core::marker::Unsize;
@@ -17,7 +16,6 @@ use core::ops;
 use core::ops::CoerceUnsized;
 use core::pin::Pin;
 use core::ptr;
-use core::ptr::NonNull;
 
 use ::alloc::alloc;
 use ::alloc::alloc::Layout;
@@ -25,17 +23,6 @@ use ::alloc::alloc::handle_alloc_error;
 use ::alloc::boxed::Box;
 
 use crate::sptr;
-
-/// A sentinel pointer that signals that the value is stored on the stack
-///
-/// It is never supposed to be dereferenced
-const INLINE_SENTINEL: *mut u8 = sptr::without_provenance_mut(0x1);
-
-/// Minimum alignment for allocations
-///
-/// Forcing a minimum alignment prevents the allocator
-/// from returning a pointer with the same address as `INLINE_SENTINEL`
-const MIN_ALIGNMENT: usize = 2;
 
 #[cfg(feature = "coerce")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized, Space> CoerceUnsized<SmallBox<U, Space>>
@@ -87,7 +74,7 @@ macro_rules! smallbox {
 /// An optimized box that store value on stack or on heap depending on its size
 pub struct SmallBox<T: ?Sized, Space> {
     space: MaybeUninit<UnsafeCell<Space>>,
-    ptr: NonNull<T>,
+    ptr: *const T,
     _phantom: PhantomData<T>,
 }
 
@@ -177,49 +164,39 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
     /// ```
     #[inline]
     pub fn is_heap(&self) -> bool {
-        self.ptr.as_ptr().cast::<u8>() != INLINE_SENTINEL
+        !self.ptr.is_null()
     }
 
     unsafe fn new_copy<U>(val: &U, metadata_ptr: *const T) -> SmallBox<T, Space>
     where U: ?Sized {
-        let layout = Layout::for_value::<U>(val);
-        let space_layout = Layout::new::<Space>();
+        let size = mem::size_of_val(val);
+        let align = mem::align_of_val(val);
 
         let mut space = MaybeUninit::<UnsafeCell<Space>>::uninit();
 
-        let (ptr_this, val_dst): (*mut u8, *mut u8) =
-            if layout.size() <= space_layout.size() && layout.align() <= space_layout.align() {
-                // Stack.
-                (INLINE_SENTINEL, space.as_mut_ptr().cast())
-            } else if layout.size() == 0 {
-                // ZST with alignment greater than Space, which will behave like being stored on
-                // heap but will not actually allocate.
-                (
-                    sptr::without_provenance_mut(layout.align()),
-                    sptr::without_provenance_mut(layout.align()),
-                )
-            } else {
-                // Heap.
-                let layout = layout
-                    // Safety: MIN_ALIGNMENT is 2, which is a valid power-of-two alignment.
-                    .align_to(MIN_ALIGNMENT)
-                    .unwrap_or_else(|_| unreachable_unchecked());
-                let heap_ptr = alloc::alloc(layout);
+        let (ptr_this, val_dst): (*mut u8, *mut u8) = if size == 0 {
+            (
+                sptr::without_provenance_mut(align),
+                sptr::without_provenance_mut(align),
+            )
+        } else if size > mem::size_of::<Space>() || align > mem::align_of::<Space>() {
+            // Heap
+            let layout = Layout::for_value::<U>(val);
+            let heap_ptr = alloc::alloc(layout);
 
-                if heap_ptr.is_null() {
-                    handle_alloc_error(layout)
-                }
+            if heap_ptr.is_null() {
+                handle_alloc_error(layout)
+            }
 
-                (heap_ptr, heap_ptr)
-            };
+            (heap_ptr, heap_ptr)
+        } else {
+            (ptr::null_mut(), space.as_mut_ptr().cast())
+        };
 
         // `self.ptr` always holds the metadata, even if stack allocated.
         let ptr = sptr::with_metadata_of_mut(ptr_this, metadata_ptr);
-        // Safety: ptr is either INLINE_SENTINEL or returned from the allocator and checked for
-        // null.
-        let ptr = NonNull::new_unchecked(ptr);
 
-        ptr::copy_nonoverlapping(sptr::from_ref(val).cast(), val_dst, layout.size());
+        ptr::copy_nonoverlapping(sptr::from_ref(val).cast(), val_dst, size);
 
         SmallBox {
             space,
@@ -254,18 +231,18 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
     #[inline]
     unsafe fn as_ptr(&self) -> *const T {
         if self.is_heap() {
-            self.ptr.as_ptr()
+            self.ptr
         } else {
-            sptr::with_metadata_of(self.space.as_ptr(), self.ptr.as_ptr())
+            sptr::with_metadata_of(self.space.as_ptr(), self.ptr)
         }
     }
 
     #[inline]
     unsafe fn as_mut_ptr(&mut self) -> *mut T {
         if self.is_heap() {
-            self.ptr.as_ptr()
+            self.ptr.cast_mut()
         } else {
-            sptr::with_metadata_of_mut(self.space.as_mut_ptr(), self.ptr.as_ptr())
+            sptr::with_metadata_of_mut(self.space.as_mut_ptr(), self.ptr.cast_mut())
         }
     }
 
@@ -292,14 +269,9 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
 
         // Just deallocates the heap memory without dropping the boxed value
         if this.is_heap() && mem::size_of::<T>() != 0 {
-            // Safety: MIN_ALIGNMENT is 2, aligning to 2 should not create an invalid layout
-            let layout = unsafe {
-                Layout::new::<T>()
-                    .align_to(MIN_ALIGNMENT)
-                    .unwrap_or_else(|_| unreachable_unchecked())
-            };
+            let layout = Layout::new::<T>();
             unsafe {
-                alloc::dealloc(this.ptr.as_ptr().cast::<u8>(), layout);
+                alloc::dealloc(this.ptr.cast_mut().cast::<u8>(), layout);
             }
         }
 
@@ -328,14 +300,12 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
     /// assert_eq!(*small_box, [1, 2, 3, 4]);
     /// ```
     pub fn from_box(boxed: ::alloc::boxed::Box<T>) -> Self {
-        unsafe {
-            let ptr = NonNull::new_unchecked(Box::into_raw(boxed));
-            let space = MaybeUninit::<UnsafeCell<Space>>::uninit();
-            SmallBox {
-                space,
-                ptr,
-                _phantom: PhantomData,
-            }
+        let ptr = Box::into_raw(boxed);
+        let space = MaybeUninit::<UnsafeCell<Space>>::uninit();
+        SmallBox {
+            space,
+            ptr,
+            _phantom: PhantomData,
         }
     }
 
@@ -461,13 +431,11 @@ impl<T: ?Sized, Space> ops::DerefMut for SmallBox<T, Space> {
 impl<T: ?Sized, Space> ops::Drop for SmallBox<T, Space> {
     fn drop(&mut self) {
         unsafe {
-            let layout = Layout::for_value::<T>(&*self)
-                .align_to(MIN_ALIGNMENT)
-                .unwrap_or_else(|_| unreachable_unchecked());
+            let layout = Layout::for_value::<T>(&*self);
 
             ptr::drop_in_place::<T>(&mut **self);
             if self.is_heap() && layout.size() != 0 {
-                alloc::dealloc(self.ptr.as_ptr().cast::<u8>(), layout);
+                alloc::dealloc(self.ptr.cast_mut().cast::<u8>(), layout);
             }
         }
     }
@@ -566,7 +534,6 @@ unsafe impl<T: ?Sized + Sync, Space> Sync for SmallBox<T, Space> {}
 #[cfg(test)]
 mod tests {
     use core::any::Any;
-    use core::mem;
     use core::ptr::addr_of;
 
     use ::alloc::boxed::Box;
@@ -813,7 +780,7 @@ mod tests {
 
         let zst: SmallBox<OveralignedZst, S1> = smallbox!(OveralignedZst);
         #[allow(clippy::as_conversions)]
-        let zst_addr = addr_of!(*zst) as usize;
+        let zst_addr = addr_of!(*zst).addr();
         assert_eq!(*zst, OveralignedZst);
         assert_eq!(zst_addr % 512, 0);
     }
@@ -830,16 +797,8 @@ mod tests {
 
         let zst: SmallBox<dyn Foo, S1> = smallbox!(OveralignedZst);
         #[allow(clippy::as_conversions)]
-        let zst_addr = addr_of!(*zst) as *const () as usize;
+        let zst_addr = addr_of!(*zst).addr();
         assert_eq!(zst_addr % 512, 0);
-    }
-
-    #[test]
-    fn test_null_ptr_optimization() {
-        assert_eq!(
-            mem::size_of::<SmallBox<i32, S1>>(),
-            mem::size_of::<Option<SmallBox<i32, S1>>>()
-        );
     }
 
     #[test]

--- a/src/smallbox.rs
+++ b/src/smallbox.rs
@@ -174,12 +174,27 @@ impl<T: ?Sized, Space> SmallBox<T, Space> {
 
         let mut space = MaybeUninit::<UnsafeCell<Space>>::uninit();
 
-        let (ptr_this, val_dst): (*mut u8, *mut u8) = if size == 0 {
-            (
-                sptr::without_provenance_mut(align),
-                sptr::without_provenance_mut(align),
-            )
-        } else if size > mem::size_of::<Space>() || align > mem::align_of::<Space>() {
+        let (ptr_this, val_dst): (*mut u8, *mut u8) =
+            if layout.size() <= space_layout.size() && layout.align() <= space_layout.align() {
+                // Layout requirement satisfied; store on stack.
+                (ptr::null_mut(), space.as_mut_ptr().cast())
+            } else if layout.size() == 0 {
+                // ZST with unsatisfied alignment; pretend to store on the heap.
+                (
+                    sptr::without_provenance_mut(layout.align()),
+                    sptr::without_provenance_mut(layout.align()),
+                )
+            } else {
+                // Otherwise, allocate on the heap.
+                let layout = Layout::for_value::<U>(val);
+                let heap_ptr = alloc::alloc(layout);
+
+                if heap_ptr.is_null() {
+                    handle_alloc_error(layout)
+                }
+
+                (heap_ptr, heap_ptr)
+            };
             // Heap
             let layout = Layout::for_value::<U>(val);
             let heap_ptr = alloc::alloc(layout);


### PR DESCRIPTION
As per #52, this reverts the non-null optimizations. Additionally to keep the CI from complaining this time, I have converted `as` pointer casts to use .cast() or .cast_mut(). I can remove this second part if needed.